### PR TITLE
Fixed bug where check_percent_memory_used always returned 0.

### DIFF
--- a/src/check_couchbase.py
+++ b/src/check_couchbase.py
@@ -285,7 +285,7 @@ def check_percent_memory_used(result):
         samples = op['samples']
         mem_used = samples['mem_used'].pop()
         max_size = samples['ep_max_size'].pop()
-    status_value = mem_used / max_size * 100
+    status_value = float(mem_used) / float(max_size) * 100
     check_levels('CB percentage of memory used', status_value, False)
 
 


### PR DESCRIPTION
Hi,
I encountered an issue where running check_couchbase.py with --percent-memory-used always returned 0.
Please let me know if this fix is satisfactory.

This is the first time I've contributed to an upstream open-source project so please let me know if I am doing anything incorrectly in the merging process.

Thanks.

--Dave Hewitt
